### PR TITLE
Simplify 433 MHz tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # pi5-433mhz-tools
-Pi5的433 MHz 简易无线通信工具库
+
+Minimal 433 MHz communication helpers for the Raspberry Pi 5 using
+[gpiozero](https://gpiozero.readthedocs.io/).
+
+## Components
+
+- `rfdevice.py` – Helper classes for sending and receiving codes.
+- `sender.py` – Send a single integer code.
+- `receive.py` – Listen and print received codes.
+
+## Usage
+
+Send a code on GPIO 17:
+
+```bash
+python3 sender.py --pin 17 1234
+```
+
+Listen for codes on GPIO 27:
+
+```bash
+python3 receive.py --pin 27
+```
+
+## License
+
+This project is released under the MIT license.

--- a/receive.py
+++ b/receive.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Listen for 433 MHz codes and print them."""
+
+import argparse
+from rfdevice import RfReceiver
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Receive 433 MHz codes")
+    parser.add_argument('--pin', type=int, default=27,
+                        help='GPIO pin connected to the receiver')
+    args = parser.parse_args()
+
+    rx = RfReceiver(args.pin)
+    print("Listening... Press Ctrl+C to exit.")
+    try:
+        while True:
+            code = rx.listen()
+            if code is not None:
+                print(f"Received {code}")
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == '__main__':
+    main()

--- a/rfdevice.py
+++ b/rfdevice.py
@@ -1,0 +1,98 @@
+"""Simple helpers for 433 MHz transmitters and receivers using gpiozero.
+
+These utilities are designed for the Raspberry Pi 5 and provide minimal
+functions to send and receive integer codes over cheap RF modules.
+"""
+
+from __future__ import annotations
+import time
+from gpiozero import DigitalInputDevice, DigitalOutputDevice
+
+
+class RfTransmitter:
+    """Transmit integer codes using a 433 MHz transmitter."""
+
+    def __init__(self, pin: int, pulse_length: float = 0.00035) -> None:
+        self.device = DigitalOutputDevice(pin)
+        self.pulse_length = pulse_length
+
+    def _tx_pulse(self, high_time: float, low_time: float) -> None:
+        self.device.on()
+        time.sleep(high_time)
+        self.device.off()
+        time.sleep(low_time)
+
+    def send_code(self, code: int, protocol: int = 1, repeat: int = 10) -> None:
+        """Send a binary code using a simple On/Off Keying protocol.
+
+        Parameters
+        ----------
+        code: int
+            The integer code to transmit.
+        protocol: int
+            Protocol number. Currently only protocol 1 is implemented.
+        repeat: int
+            Number of times to repeat the code for reliability.
+        """
+        if protocol != 1:
+            raise ValueError("Only protocol 1 is implemented")
+
+        binary = format(code, 'b')
+        for _ in range(repeat):
+            for bit in binary:
+                if bit == '1':
+                    self._tx_pulse(self.pulse_length, self.pulse_length * 3)
+                else:
+                    self._tx_pulse(self.pulse_length, self.pulse_length)
+            # sync gap
+            time.sleep(self.pulse_length * 31)
+
+
+class RfReceiver:
+    """Receive codes from a 433 MHz receiver."""
+
+    def __init__(self, pin: int, threshold: float = 0.001) -> None:
+        self.device = DigitalInputDevice(pin, pull_up=False)
+        self.threshold = threshold
+        self.last_code: int | None = None
+        self.last_timestamp: float | None = None
+
+    def _record_pulses(self, duration: float = 0.02) -> list[float]:
+        pulses = []
+        start = time.monotonic()
+        last_time = start
+        last_state = self.device.value
+        while time.monotonic() - start < duration:
+            state = self.device.value
+            if state != last_state:
+                now = time.monotonic()
+                pulses.append(now - last_time)
+                last_time = now
+                last_state = state
+        return pulses
+
+    def _decode_pulses(self, pulses: list[float]) -> int | None:
+        if len(pulses) < 2:
+            return None
+        binary = ''
+        for pulse in pulses:
+            binary += '1' if pulse > self.threshold else '0'
+        try:
+            return int(binary, 2)
+        except ValueError:
+            return None
+
+    def listen(self, listen_time: float = 0.02) -> int | None:
+        """Listen for a single code.
+
+        Parameters
+        ----------
+        listen_time: float
+            How long to capture pulses in seconds.
+        """
+        pulses = self._record_pulses(listen_time)
+        code = self._decode_pulses(pulses)
+        if code is not None:
+            self.last_code = code
+            self.last_timestamp = time.time()
+        return code

--- a/sender.py
+++ b/sender.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Transmit integer codes using a 433 MHz transmitter."""
+
+import argparse
+from rfdevice import RfTransmitter
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Send a 433 MHz code")
+    parser.add_argument('--pin', type=int, default=17,
+                        help='GPIO pin connected to the transmitter')
+    parser.add_argument('code', type=int, help='Integer code to transmit')
+    args = parser.parse_args()
+
+    tx = RfTransmitter(args.pin)
+    tx.send_code(args.code)
+    print(f"Sent {args.code}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- drop rfchat example and BSD license
- provide simple sender.py and receive.py scripts
- trim README and remove upstream references
- keep MIT license

## Testing
- `python3 -m py_compile rfdevice.py sender.py receive.py`


------
https://chatgpt.com/codex/tasks/task_e_686f2a720ab083318efe4b9f8c7f0f5f