### PR TITLE
Add protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Minimal 433 MHz communication helpers for the Raspberry Pi 5 using
 [gpiozero](https://gpiozero.readthedocs.io/).
+The helper classes support multiple protocols similar to
+[rpi-rf](https://github.com/milaq/rpi-rf).
 
 ## Components
 
@@ -14,13 +16,13 @@ Minimal 433 MHz communication helpers for the Raspberry Pi 5 using
 Send a code on GPIO 17:
 
 ```bash
-python3 sender.py --pin 17 1234
+python3 sender.py --pin 17 --protocol 1 1234
 ```
 
 Listen for codes on GPIO 27:
 
 ```bash
-python3 receive.py --pin 27
+python3 receive.py --pin 27 --protocol 1
 ```
 
 ## License

--- a/receive.py
+++ b/receive.py
@@ -2,16 +2,21 @@
 """Listen for 433 MHz codes and print them."""
 
 import argparse
+
 from rfdevice import RfReceiver
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Receive 433 MHz codes")
-    parser.add_argument('--pin', type=int, default=27,
-                        help='GPIO pin connected to the receiver')
+    parser.add_argument(
+        "--pin", type=int, default=27, help="GPIO pin connected to the receiver"
+    )
+    parser.add_argument(
+        "--protocol", type=int, default=1, help="Reception protocol (default: 1)"
+    )
     args = parser.parse_args()
 
-    rx = RfReceiver(args.pin)
+    rx = RfReceiver(args.pin, protocol=args.protocol)
     print("Listening... Press Ctrl+C to exit.")
     try:
         while True:
@@ -22,5 +27,5 @@ def main() -> None:
         pass
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/sender.py
+++ b/sender.py
@@ -2,20 +2,25 @@
 """Transmit integer codes using a 433 MHz transmitter."""
 
 import argparse
+
 from rfdevice import RfTransmitter
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Send a 433 MHz code")
-    parser.add_argument('--pin', type=int, default=17,
-                        help='GPIO pin connected to the transmitter')
-    parser.add_argument('code', type=int, help='Integer code to transmit')
+    parser.add_argument(
+        "--pin", type=int, default=17, help="GPIO pin connected to the transmitter"
+    )
+    parser.add_argument(
+        "--protocol", type=int, default=1, help="Transmission protocol (default: 1)"
+    )
+    parser.add_argument("code", type=int, help="Integer code to transmit")
     args = parser.parse_args()
 
-    tx = RfTransmitter(args.pin)
+    tx = RfTransmitter(args.pin, protocol=args.protocol)
     tx.send_code(args.code)
     print(f"Sent {args.code}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add PROTOCOLS constant for multiple protocols
- support protocol selection in RfTransmitter and RfReceiver
- add protocol option to sender and receiver CLI tools
- update README

## Testing
- `python3 -m py_compile rfdevice.py sender.py receive.py`
- `isort rfdevice.py sender.py receive.py`
- `black -q rfdevice.py sender.py receive.py`

------
https://chatgpt.com/codex/tasks/task_e_686f311fe7d08331b283522a8a643c0a