### PR TITLE
Fix CPU load in receiver loop

### DIFF
--- a/receive.py
+++ b/receive.py
@@ -2,6 +2,7 @@
 """Listen for 433 MHz codes and print them."""
 
 import argparse
+import time
 
 from rfdevice import RfReceiver
 
@@ -23,6 +24,7 @@ def main() -> None:
             code = rx.listen()
             if code is not None:
                 print(f"Received {code}")
+            time.sleep(0.01)
     except KeyboardInterrupt:
         pass
 


### PR DESCRIPTION
## Summary
- reduce CPU usage by adding a small sleep in the receive loop

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_686f58f96d908331bb389a24146be429