### PR TITLE
Add PiGPIOFactory requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,18 @@ Minimal 433 MHz communication helpers for the Raspberry Pi 5 using
 
 - Python 3
 - [`gpiozero`](https://gpiozero.readthedocs.io/)
+- [`pigpio`](http://abyz.me.uk/rpi/pigpio/)
 
-Install the GPIO Zero library with:
+Install the libraries with:
 
 ```bash
-pip install gpiozero
+pip install gpiozero pigpio
+```
+
+The ``pigpiod`` daemon must be running. Start it with:
+
+```bash
+sudo pigpiod
 ```
 
 ## Components


### PR DESCRIPTION
## Summary
- force use of `PiGPIOFactory` for both transmitter and receiver
- check the connection to `pigpiod` on initialization
- document pigpio as a requirement and show how to run `pigpiod`

## Testing
- `python -m compileall -q .`
- `python sender.py -h` *(fails: ModuleNotFoundError: No module named 'gpiozero')*


------
https://chatgpt.com/codex/tasks/task_e_6870aaedde4c8331853cedf6042b348b